### PR TITLE
spaCy: Added GPU support and prefer GPU

### DIFF
--- a/duui-spacy/requirements.txt
+++ b/duui-spacy/requirements.txt
@@ -41,7 +41,7 @@ requests==2.27.1
 smart-open==5.2.1
 sniffio==1.2.0
 sortedcontainers==2.4.0
-spacy==3.2.2
+spacy[cuda12x]==3.2.2
 spacy-legacy==3.0.8
 spacy-loggers==1.0.1
 spacy-pkuseg==0.0.28

--- a/duui-spacy/src/main/python/textimager_duui_spacy.py
+++ b/duui-spacy/src/main/python/textimager_duui_spacy.py
@@ -331,6 +331,8 @@ with open(lua_communication_script_filename, 'rb') as f:
 @lru_cache_with_size
 def load_cache_spacy_model(model_name):
     logger.info("Loading spaCy model \"%s\"...", model_name)
+    spacy.prefer_gpu()
+    logger.info("Using GPU if possible")
     nlp = spacy.load(model_name)
     logger.info("Finished loading spaCy model \"%s\"", model_name)
     return nlp


### PR DESCRIPTION
I changed the spaCy dependency to support the latest CUDA driver and made it so that the GPU is preferred to run the model.