### PR TITLE
support long prompts, leave no token behind

### DIFF
--- a/duui-text-to-image/src/main/python/duui_text_to_image.py
+++ b/duui-text-to-image/src/main/python/duui_text_to_image.py
@@ -50,6 +50,10 @@ lora_models = {
     "hassanelmghari/shou_xin": "hassanelmghari/shou_xin",
 }
 
+models_prompts_handler = {
+    "OFA-Sys/small-stable-diffusion-v0": "handle_long_prompts",
+}
+
 class UimaSentence(BaseModel):
     text: str
     begin: int
@@ -242,9 +246,11 @@ def check_and_tokenize_input(pipe, input_text, truncate):
     max_length = pipe.tokenizer.model_max_length
 
     # Tokenize the input
-    inputs = pipe.tokenizer(input_text, return_tensors="pt", truncation=truncate, padding=True)
+    inputs = pipe.tokenizer(input_text, return_tensors="pt", padding=True)
     
     token_sequence_length = len(inputs['input_ids'][0])
+
+    logger.debug(f"Token sequence length: {token_sequence_length}")
 
     if token_sequence_length > max_length and not truncate:
         return None, f"Input exceeds model max length ({token_sequence_length} > {max_length})"
@@ -252,33 +258,96 @@ def check_and_tokenize_input(pipe, input_text, truncate):
     return inputs, None
 
 
-def calculate_embedding(pipe, prompt, truncate_text=False):
+def calculate_embeddings(pipe, prompt, negative_prompt="", truncate_text=False, device='cuda', pooling_strategy='mean'):
     """
-    calculate the embeddings of the prompt and return the values
-    The prompt is split into chunks of max_length and the embeddings are concatenated
-    Use the model tokenizer to tokenize the prompt and the negative prompt
-    #TODO: add a more appropriate way to handle the negative prompt
+    Calculate the embeddings of the prompt and negative prompt, and return both token embeddings and pooled embeddings.
+
+    This function splits the prompt into chunks of the model's max token length, calculates embeddings for each chunk,
+    applies pooling to the embeddings, and then returns both the raw token embeddings and the pooled embeddings.
+
+    Args:
+        pipe: The pipeline object containing the tokenizer and text encoder.
+        prompt (str): The input text for which embeddings are calculated.
+        negative_prompt (str, optional): The negative prompt (default is an empty string).
+        truncate_text (bool, optional): Whether to truncate the text if it exceeds the model's maximum length (default is False).
+        device (str, optional): The device to use for tensors ('cpu' or 'cuda', default is 'cuda').
+        pooling_strategy (str, optional): The pooling strategy ('mean' or 'max') to apply to the embeddings (default is 'mean').
+
+    Returns:
+        tuple: A tuple containing:
+            - prompt_embeds (torch.Tensor): The raw token embeddings for the prompt.
+            - negative_prompt_embeds (torch.Tensor): The raw token embeddings for the negative prompt.
+            - pooled_prompt_embeds (torch.Tensor): The pooled embeddings for the prompt.
+            - pooled_negative_prompt_embeds (torch.Tensor): The pooled embeddings for the negative prompt.
     """
-    
-    # clacualte the embeddiings of the prompt and return the values
+
+    # Tokenizer max length
     max_length = pipe.tokenizer.model_max_length
 
-    input_ids = pipe.tokenizer(prompt, truncation=truncate_text, return_tensors="pt").input_ids
-    input_ids = input_ids.to(device)
+    # Tokenize input prompt and negative prompt
+    input_ids = pipe.tokenizer(prompt, truncation=truncate_text, return_tensors="pt").input_ids.to(device)
+    negative_ids = pipe.tokenizer(negative_prompt, truncation=truncate_text, padding="max_length",
+                                  max_length=input_ids.shape[-1], return_tensors="pt").input_ids.to(device)
 
-    negative_ids = pipe.tokenizer("", truncation=truncate_text, padding="max_length", max_length=input_ids.shape[-1], return_tensors="pt").input_ids                                                                                                     
-    negative_ids = negative_ids.to(device)
+    # Split into chunks and calculate embeddings, then apply pooling
+    prompt_embeds = _get_token_embeddings(pipe, input_ids, max_length)
+    negative_prompt_embeds = _get_token_embeddings(pipe, negative_ids, max_length)
 
-    concat_embeds = []
-    neg_embeds = []
+    # Apply pooling to get pooled embeddings
+    pooled_prompt_embeds = _apply_pooling(prompt_embeds, pooling_strategy)
+    pooled_negative_prompt_embeds = _apply_pooling(negative_prompt_embeds, pooling_strategy)
+
+    # Ensure the embeddings are in the correct shape for the pipeline
+    prompt_embeds = prompt_embeds.view(input_ids.shape[0], -1, prompt_embeds.shape[-1])  # Add batch dimension
+    negative_prompt_embeds = negative_prompt_embeds.view(negative_ids.shape[0], -1, negative_prompt_embeds.shape[-1])
+
+    return prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, pooled_negative_prompt_embeds
+
+
+def _get_token_embeddings(pipe, input_ids, max_length):
+    """
+    Helper function to split the input_ids into chunks, calculate the embeddings for each chunk.
+
+    Args:
+        pipe: The pipeline object containing the text encoder.
+        input_ids (torch.Tensor): The tokenized input.
+        max_length (int): The maximum length of each chunk.
+
+    Returns:
+        torch.Tensor: The raw token embeddings for the input.
+    """
+    # Initialize list to store embeddings for each chunk
+    chunk_embeddings = []
+
+    # Split input into chunks of max_length and calculate embeddings
     for i in range(0, input_ids.shape[-1], max_length):
-        concat_embeds.append(pipe.text_encoder(input_ids[:, i: i + max_length])[0])
-        neg_embeds.append(pipe.text_encoder(negative_ids[:, i: i + max_length])[0])
+        chunk = input_ids[:, i:i + max_length]
+        chunk_embeddings.append(pipe.text_encoder(chunk)[0])  # The output of text_encoder is (embeddings, hidden_states)
 
-    prompt_embeds = torch.cat(concat_embeds, dim=1)
-    negative_prompt_embeds = torch.cat(neg_embeds, dim=1)
-    
-    return prompt_embeds, negative_prompt_embeds
+    # Concatenate all the chunk embeddings
+    return torch.cat(chunk_embeddings, dim=1)
+
+
+def _apply_pooling(embeddings, pooling_strategy):
+    """
+    Apply pooling (mean or max) to the token embeddings to get a fixed-size representation.
+
+    Args:
+        embeddings (torch.Tensor): The token embeddings.
+        pooling_strategy (str): The pooling strategy to use ('mean' or 'max').
+
+    Returns:
+        torch.Tensor: The pooled embeddings.
+    """
+    if pooling_strategy == 'mean':
+        pooled_embeddings = torch.mean(embeddings, dim=1)  # Mean pooling across token length
+    elif pooling_strategy == 'max':
+        pooled_embeddings, _ = torch.max(embeddings, dim=1)  # Max pooling across token length
+    else:
+        raise ValueError(f"Invalid pooling strategy: {pooling_strategy}. Choose 'mean' or 'max'.")
+
+    return pooled_embeddings
+
 
 
 def process_selection(model_name, selection, model_config=None):
@@ -286,7 +355,7 @@ def process_selection(model_name, selection, model_config=None):
     Process a selection of sentences and return the results.
     handle long prompts by splitting them into chunks of max_length
     """
-    
+
     # Initialize output containers
     begin, end, results_out, factors, len_results, errors_list = [], [], [], [], [], []
 
@@ -306,35 +375,51 @@ def process_selection(model_name, selection, model_config=None):
             for c, sentence in enumerate(selection.sentences):
                 text = texts[c]
                 inputs, error_message = check_and_tokenize_input(pipe, text, model_config["truncate_text"])
-
-                # Handle errors related to tokenization if the text is not truncated
-                if error_message and not model_config["truncate_text"]:
-                    errors_list.append(error_message)
-                    continue
-                else:
-                    print("Input is within the allowed sequence length.")
-
-                # anycase we need to calculate the embeddings
-                prompt_embeds, negative_prompt_embeds = calculate_embedding(pipe, text, model_config["truncate_text"])
-                
                 # Initialize variables for this sentence
                 begin.append(sentence.begin)
                 end.append(sentence.end)
                 factors.append([1.0])  # Dummy factor
                 len_results.append(1)  # One image per text
 
-                # Perform inference if there are no tokenization errors
-                results = pipe(
-                    prompt_embeds=prompt_embeds, 
-                    negative_prompt_embeds=negative_prompt_embeds,
-                    num_inference_steps=model_config["num_inference_steps"],
-                    num_images_per_prompt=model_config["number_of_images"],
-                    image_width=model_config["image_width"],
-                    image_height=model_config["image_height"],
-                    generator=generator
-                )
+                # Handle errors related to tokenization if the text is not truncated
+                if error_message and not model_config["truncate_text"] and model_name in models_prompts_handler:
+                    error_message += " The input will use embeddings for the prompts tokens."
+                    errors_list.append(error_message)
+                    prompt_embeds, negative_prompt_embeds, pooled_prompt_embeds, pooled_negative_prompt_embeds = calculate_embeddings(pipe, text, truncate_text=False)
+                    # Perform inference if there are no tokenization errors
+                    results = pipe(
+                        prompt_embeds=prompt_embeds,
+                        negative_prompt_embeds=negative_prompt_embeds,
+                        pooled_prompt_embeds=pooled_prompt_embeds,
+                        negative_pooled_prompt_embeds=pooled_negative_prompt_embeds,
+                        num_inference_steps=model_config["num_inference_steps"],
+                        num_images_per_prompt=model_config["number_of_images"],
+                        image_width=model_config["image_width"],
+                        image_height=model_config["image_height"],
+                        generator=generator
+                    )
 
-                results_out.append([image for image in results['images']])
+                    results_out.append([image for image in results['images']])
+                #     continue
+                elif error_message and not model_config["truncate_text"] and model_name not in models_prompts_handler:
+                    error_message += " Set truncate_text to True, or use a smaller prompt."
+                    errors_list.append(error_message)
+                    continue
+                else:
+                    # Perform inference if there are no tokenization errors
+                    results = pipe(
+                        prompt=text,
+                        num_inference_steps=model_config["num_inference_steps"],
+                        num_images_per_prompt=model_config["number_of_images"],
+                        image_width=model_config["image_width"],
+                        image_height=model_config["image_height"],
+                        generator=generator
+                    )
+                    results_out.append([image for image in results['images']])
+
+
+
+
 
             logger.debug("Inference done")
             pipe.to("cpu")  # Free memory by moving the model back to CPU


### PR DESCRIPTION
* bypassing the tokenizer's limitations by calculating the embeddings manually.
* The issue is not solving the problem 100%, but it's still taking into account the long context (tested).
* Improve the "negative_prompt_embeds" with more sentiment information.