### PR TITLE
update torch to 2.5.0 and lightening to 2.4.0

### DIFF
--- a/duui-transformers-berttopic/requirements.txt
+++ b/duui-transformers-berttopic/requirements.txt
@@ -1,12 +1,12 @@
-torch==2.3.0
-torchaudio==2.3.0
-torchvision==0.18.0
+torch==2.5.0
+torchvision==0.20.0
+torchaudio==2.5.0
 scipy==1.13.1
 transformers==4.41.2
 sentencepiece==0.2.0
 protobuf==4.25.3
 germansentiment==1.1.0
-pytorch-lightning==2.2.5
+pytorch-lightning==2.4.0
 numpy==1.26.3
 scikit-learn==1.5.0
 nltk==3.7

--- a/duui-transformers-berttopic/src/main/docker/Dockerfile-cuda
+++ b/duui-transformers-berttopic/src/main/docker/Dockerfile-cuda
@@ -28,7 +28,7 @@ COPY ./src/main/python/duui-transformers-berttopic.lua ./duui-transformers-bertt
 RUN apt-get remove python3-blinker -y
 RUN pip install blinker==1.6.2
 
-RUN pip install torch==2.3.0 torchvision==0.18.0 torchaudio==2.3.0 --index-url https://download.pytorch.org/whl/cu118
+RUN pip install torch==2.5.0 torchvision==0.20.0 torchaudio==2.5.0 --index-url https://download.pytorch.org/whl/cu118
 COPY ./requirements.txt ./requirements.txt
 RUN pip install -r requirements.txt
 


### PR DESCRIPTION
This PR update the torch version to 2.5.0 and pytorch-lightening version to 2.4.0([patched version](https://github.com/advisories/GHSA-4cv3-v7pv-rfhf)).