### PR TITLE
Remove redundant setting of begin and end in taxon resolution

### DIFF
--- a/duui-taxon-resolver/src/main/lua/communication_layer.lua
+++ b/duui-taxon-resolver/src/main/lua/communication_layer.lua
@@ -308,8 +308,6 @@ function deserialize(inputCas, inputStream)
 
         for i, linking in ipairs(linkings) do
             local taxon_resolution = luajava.newInstance("org.texttechnologylab.annotation.type.TaxonResolution", inputCas)
-            taxon_resolution:setBegin(begin)
-            taxon_resolution:setEnd(end_)
             taxon_resolution:setRecognizedTaxon(recognized_taxon)
             populateTaxonResolution(taxon_resolution, linking)
             taxon_resolution:addToIndexes()


### PR DESCRIPTION
fix: remove redundant (and now erroneous) setting of begin and end in taxon resolution